### PR TITLE
migrate to friendly public transport format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ A **collection of all lines (and their stations) of the [Berlin Brandenburg publ
 
 [![npm version](https://img.shields.io/npm/v/vbb-lines.svg)](https://www.npmjs.com/package/vbb-lines)
 [![build status](https://img.shields.io/travis/derhuerst/vbb-lines.svg)](https://travis-ci.org/derhuerst/vbb-lines)
-[![dependency status](https://img.shields.io/david/derhuerst/vbb-lines.svg)](https://david-dm.org/derhuerst/vbb-lines)
-[![dev dependency status](https://img.shields.io/david/dev/derhuerst/vbb-lines.svg)](https://david-dm.org/derhuerst/vbb-lines#info=devDependencies)
 ![ISC-licensed](https://img.shields.io/github/license/derhuerst/vbb-lines.svg)
 [![gitter channel](https://badges.gitter.im/derhuerst/vbb-rest.svg)](https://gitter.im/derhuerst/vbb-rest)
 
@@ -18,6 +16,23 @@ npm install vbb-lines
 
 
 ## Usage
+
+This module contains data in the [*Friendly Public Transport Format*](https://github.com/public-transport/friendly-public-transport-format).
+
+```js
+{
+	type: 'line',
+	id: '17519_400',
+	name: 'U55',
+	operator: '796',
+	mode: 'train',
+	product: 'subway',
+	variants: [
+		['070201054601', '070201054501', '070201054401'], // station ids
+		['070201054401', '070201054501', '070201054601']
+	]
+}
+```
 
 ```js
 const lines = require('vbb-lines')

--- a/convert.js
+++ b/convert.js
@@ -16,7 +16,17 @@ const writeNDJSON = (data, file) => new Promise((yay, nay) => {
 	for (let key in data) out.write(data[key])
 })
 
-const lineTypes = {
+const modes = {
+	'100': 'train',
+	'102': 'train',
+	'109': 'train',
+	'400': 'train',
+	'700': 'bus',
+	'900': 'tram',
+	'1000': 'ferry'
+}
+
+const products = {
 	'100': 'regional',
 	'102': 'regional',
 	'109': 'suburban',
@@ -37,9 +47,12 @@ const fetchLines = () => new Promise((yay, nay) => {
 	.on('data', (line) => {
 		const id = line.route_id
 		lines[id + ''] = {
-			id, name: line.route_short_name,
-			agencyId: line.agency_id,
-			type: lineTypes[line.route_type] || 'unknown',
+			type: 'line',
+			id,
+			name: line.route_short_name,
+			operator: line.agency_id,
+			mode: modes[line.route_type],
+			product: products[line.route_type] || null,
 			variants: []
 		}
 	})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name":              "vbb-lines",
 	"description":       "VBB lines and their stations.",
-	"version":           "2.3.0",
+	"version":           "3.0.0",
 	"main":              "index.js",
 	"files":             ["index.js", "data.ndjson", "vbb-logo.jpg"],
 	"keywords": [
@@ -13,6 +13,7 @@
 	"repository":        "git://github.com/derhuerst/vbb-lines.git",
 	"bugs":              "https://github.com/derhuerst/vbb-lines/issues",
 	"license":           "ISC",
+	"engines":           {"node": ">=6"},
 	"dependencies": {
 		"ndjson":         "^1.5.0",
 		"stream-filter":  "^2.1.0",


### PR DESCRIPTION
The `variants` field is non-idiomatic, but I kept it for now as using `route`s would be significantly more data. Will migrate to `route`s eventually though.

Also, right now (and afaik we decided that this makes sense) `route`s reference `line`s, not the opposite. This is contrary to how this module works.

@juliuste